### PR TITLE
Change clicking pace.

### DIFF
--- a/src/cljck/timing.clj
+++ b/src/cljck/timing.clj
@@ -1,13 +1,35 @@
 (ns cljck.timing
   (:require [cljck.io :refer [click]]
-            [clojure.core.async :refer [<!! go-loop timeout]]))
+            [clojure.core.async :refer [<! >! chan go-loop timeout]]))
 
-(defn timed-clicking
-  "Starts clicking the given button n times per second.
-  Button should be one of: :left :middle :right"
-  [n button]
-  (let [interval (/ 1000 n)]
-    (go-loop []
-      (<!! (timeout interval))
-      (click button)
-      (recur))))
+(def click-state
+  "This is the state of the clicking and controls such things as clicks per
+  second and the various open channels."
+  (atom {:active false
+         :bucket (chan)
+         :cps 1}))
+
+(defn set-clicks-per-second!
+  "Starts clicking the left mouse button n times per second. Will stop
+  clicking if n is zero."
+  [n]
+  {:pre [(number? n)
+         (<= 0 n 100)]}
+  (if (pos? n)
+    (do
+      (swap! click-state assoc :cps n)
+      (swap! click-state assoc :active true))
+    (swap! click-state assoc :active false)))
+
+;; Keep adding tokens to the 'click bucket' when actively clicking.
+(go-loop []
+  (when (:active @click-state)
+    (>! (:bucket @click-state) :click))
+  (<! (timeout (/ 1000 (:cps @click-state))))
+  (recur))
+
+;; Click as soon as a token is added to the 'click bucket'.
+(go-loop []
+  (<! (:bucket @click-state))
+  (click :left)
+  (recur))


### PR DESCRIPTION
This adds the ability to change clicking pace and introduces the concept of a "token bucket". As soon as a token is put into the bucket (a core.async chan), a click is performed. A separate go-loop puts tokens into the bucket if the clicking engine is active, and then waits for the desired interval. This interval is kept in an atom and can be changed at any time. A convenience function is provided to easily set a new clicking pace.

This closes #3.
