### PR TITLE
Uberjar capable of processing EDN file.

### DIFF
--- a/boot.properties
+++ b/boot.properties
@@ -1,0 +1,4 @@
+#https://github.com/boot-clj/boot
+#Mon Aug 31 21:40:12 CEST 2015
+BOOT_CLOJURE_VERSION=1.7.0
+BOOT_VERSION=2.2.0

--- a/build.boot
+++ b/build.boot
@@ -1,5 +1,17 @@
 (set-env!
   :dependencies
-  '[[org.clojure/core.async "0.1.346.0-17112a-alpha"]
+  '[[org.clojure/clojure "1.7.0"]
+    [org.clojure/core.async "0.1.346.0-17112a-alpha"]
     [seesaw "1.4.5"]]
   :source-paths #{"src"})
+
+(deftask build
+  "Builds an uberjar capable of processing files passed to it on the command
+  line."
+  []
+  (comp
+   (aot :namespace '#{cljck.io})
+   (pom :project 'cljck
+        :version "0.1.0")
+   (uber)
+   (jar :main 'cljck.io)))

--- a/src/cljck/io.clj
+++ b/src/cljck/io.clj
@@ -1,4 +1,5 @@
 (ns cljck.io
+  (:gen-class)
   (:require [clojure.core.async :refer [<! <!! chan go-loop timeout]]
             [clojure.edn :as edn])
   (:import  [java.awt Robot]
@@ -75,3 +76,7 @@
   "Takes a file name, reads the content of the file, parses it as EDN, and
   attempts to process it as a Cljck command."
   (comp process-event edn/read-string slurp))
+
+(defn -main
+  [file-name]
+  (process-file file-name))

--- a/test.edn
+++ b/test.edn
@@ -1,0 +1,2 @@
+[:repeat 3
+ [:click]]


### PR DESCRIPTION
It's now possible to compile an uberjar using `boot build`. Having created a jar, you can run it as follows:
- `java -jar .../target/cljck-0.1.0.jar myfile.edn`

This closes #13.
