### PR TITLE
Send key presses

### DIFF
--- a/src/cljck/io/images.clj
+++ b/src/cljck/io/images.clj
@@ -1,0 +1,10 @@
+(ns cljck.io.images
+  (:import
+   [java.io File]
+   [javax.imageio ImageIO]))
+
+(defn buffered-image
+  "Takes a path to an image file, which is assumed available on the class path,
+  and constructs and returns a BufferedImage from it."
+  [path]
+  (ImageIO/read (File. ^String path)))

--- a/src/cljck/io/keyboard.clj
+++ b/src/cljck/io/keyboard.clj
@@ -1,7 +1,7 @@
 (ns cljck.io.keyboard
   (:import [java.awt AWTKeyStroke]
            [java.awt.event InputEvent KeyEvent])
-  (:require [cljck.io :refer [robot]]))
+  (:require [cljck.io.sync :refer [robot]]))
 
 (def bitmask-map
   {(bit-or InputEvent/ALT_DOWN_MASK InputEvent/ALT_MASK)

--- a/src/cljck/io/mouse.clj
+++ b/src/cljck/io/mouse.clj
@@ -1,0 +1,23 @@
+(ns cljck.io.mouse
+  (:require [cljck.io.sync :refer [robot]])
+  (:import [java.awt.event InputEvent]))
+
+(def button-map
+  "A mapping from Clojure keywords to more long-winded Java enums."
+  {:left   InputEvent/BUTTON1_DOWN_MASK
+   :middle InputEvent/BUTTON2_DOWN_MASK
+   :right  InputEvent/BUTTON3_DOWN_MASK})
+
+(defn click
+  "Simulates a mouse click of the key denoted by the keyword k in the
+  button-map. A click is really a press and a release in succession."
+  [k]
+  (let [i (get button-map k InputEvent/BUTTON1_DOWN_MASK)]
+    (doto robot
+      (.mousePress i)
+      (.mouseRelease i))))
+
+(defn move-to
+  "Moves the mouse cursor to the absolute position [x y] on the screen."
+  [x y]
+  (.mouseMove robot x y))

--- a/src/cljck/io/sync.clj
+++ b/src/cljck/io/sync.clj
@@ -1,0 +1,6 @@
+(ns cljck.io.sync
+  (:import [java.awt Robot]))
+
+(def robot
+  "You need a robot to do stuff with the mouse. This is that robot."
+  (Robot.))


### PR DESCRIPTION
This introduces the ability to simulate pressing keys with optional modifiers. I've opted to use the format from [AWTKeyStroke](https://docs.oracle.com/javase/7/docs/api/java/awt/AWTKeyStroke.html) for the strings.

This closes #15.
