### PR TITLE
Fix kill switch issue

### DIFF
--- a/src/cljck/io.clj
+++ b/src/cljck/io.clj
@@ -71,6 +71,7 @@
      (nativeKeyReleased [event])
      (nativeKeyPressed [event]
        (when (= (.getKeyCode event) NativeKeyEvent/VC_ESCAPE)
+         (GlobalScreen/unregisterNativeHook)
          (System/exit 1337)))))
   
   (go-loop []


### PR DESCRIPTION
Hopefully this fixes the issues with the kill switch key binding. Before we made no attempt to unregister hooks before exiting the program, which potentially caused some issues with repeated use. The bot should now correctly unregister its global hooks before shutting down, and hopefully this was causing the issue.

I've been unable to reproduce the issue on Ubuntu and unwilling to develop the bot on Windows, which has lead to this "patch and pray" approach. Am I a terrible person? Yes.
