### PR TITLE
[#22] Process multiple scripts from command line.

### DIFF
--- a/src/cljck/io.clj
+++ b/src/cljck/io.clj
@@ -4,7 +4,7 @@
    [cljck.io
     [keyboard :refer [press]]
     [mouse :refer [click move-to]]]
-   [clojure.core.async :refer [<! <!! chan go-loop timeout]]
+   [clojure.core.async :refer [<! <!! chan go go-loop timeout]]
    [clojure.edn :as edn])
   (:import
    [java.util.logging Level Logger]
@@ -59,7 +59,7 @@
   (comp process-event edn/read-string slurp))
 
 (defn -main
-  [file-name]
+  [& file-names]
   (doto (Logger/getLogger "org.jnativehook")
     (.setLevel Level/OFF))
   
@@ -78,4 +78,5 @@
     (process-event (<! event-channel))
     (recur))
 
-  (process-file file-name))
+  (doseq [file-name file-names]
+    (go (process-file file-name))))


### PR DESCRIPTION
This simply spawns a go block for each file passed as argument and prays that the concurrency works out. It works well for the simple sample scripts I've tested.

This closes #22.
