### PR TITLE
Add 'compare histograms' command

### DIFF
--- a/src/cljck/io.clj
+++ b/src/cljck/io.clj
@@ -1,8 +1,11 @@
 (ns cljck.io
   (:gen-class)
   (:require
-   [cljck.utils :refer [multi-functions]]
+   [cljck
+    [color :refer [hex->histogram histogram histogram-diff]]
+    [utils :refer [multi-functions]]]
    [cljck.io
+    [images :refer [fetch-screen]]
     [keyboard :refer [press]]
     [mouse :refer [click move-to mouse-pointer scroll-down scroll-up]]]
    [clojure.core.async :refer [<! <!! chan go go-loop timeout]]
@@ -36,6 +39,18 @@
 (defmethod process-event "click"
   [_]
   (click :left))
+
+(defmethod process-event "histogram"
+  [[_ hex-code]]
+  (hex->histogram hex-code))
+
+(defmethod process-event "histogram-at"
+  [[_ x y width height]]
+  (histogram (fetch-screen x y width height)))
+
+(defmethod process-event "histogram-diff"
+  [[_ hist1 hist2 max-diff]]
+  (<= (histogram-diff (process-event hist1) (process-event hist2)) max-diff))
 
 (defmethod process-event "if"
   [[_ condition then else]]

--- a/src/cljck/io/images.clj
+++ b/src/cljck/io/images.clj
@@ -1,10 +1,27 @@
 (ns cljck.io.images
+  (:require [cljck.io.sync :refer [robot]])
   (:import
+   [java.awt Rectangle Toolkit]
+   [java.awt.image BufferedImage]
    [java.io File]
    [javax.imageio ImageIO]))
+
+(defn screen-resolution
+  "Returns the current width and height of the screen."
+  []
+  ((juxt (memfn getWidth) (memfn getHeight))
+   (.. Toolkit getDefaultToolkit getScreenSize)))
 
 (defn buffered-image
   "Takes a path to an image file, which is assumed available on the class path,
   and constructs and returns a BufferedImage from it."
   [path]
   (ImageIO/read (File. ^String path)))
+
+(defn fetch-screen
+  "Returns a BufferedImage of the pixels currently on the screen. Optionally
+  takes a rectangle to limit the fetching to."
+  ([]
+   (apply fetch-screen 0 0 (screen-resolution)))
+  ([x y width height]
+   (.createScreenCapture robot (Rectangle. x y width height))))


### PR DESCRIPTION
**Work in progress**

This adds the ability to:

- Create a histogram given a literal string encoding of one.
- Create a histogram from a rectangle of pixels on the screen.
- A condition comparing whether two histograms are sufficiently
  similar.

This allows branching based on the contents on the screen compared
a known earlier state (which must be precomputed and encoded for now.)

This closes #32.