### PR TITLE
Add `holding` command

### DIFF
--- a/src/cljck/io/keyboard.clj
+++ b/src/cljck/io/keyboard.clj
@@ -26,12 +26,18 @@
     (keys bitmask-map))
    (map (partial get bitmask-map))))
 
-(defn press
+(defn key-string->key-seq
   [key-string]
   (let [[key-code mod-mask] (str->key-stroke key-string)
-        mod-seq (vec (bitmask->key-events mod-mask))
-        key-seq (conj mod-seq key-code)]
-    (doseq [k key-seq]
-      (.keyPress robot k))
-    (doseq [k (reverse key-seq)]
-      (.keyRelease robot k))))
+        mod-seq (vec (bitmask->key-events mod-mask))]
+    (conj mod-seq key-code)))
+
+(defn press
+  [key-string]
+  (doseq [k (key-string->key-seq key-string)]
+    (.keyPress robot k)))
+
+(defn release
+  [key-string]
+  (doseq [k (reverse (key-string->key-seq key-string))]
+    (.keyRelease robot k)))


### PR DESCRIPTION
This command simulates holding down a key (with potential modifier
keys), performing arbitrary other commands, and then releasing the
key. It's particularly useful for holding a key while performing
mouse commands.

Closes #35.